### PR TITLE
Fix warnings and errors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "purescript-exceptions": "~0.3.1",
     "purescript-foreign": "~0.7.1",
-    "purescript-generics": "~0.6.2",
+    "purescript-generics": "~0.7.2",
     "purescript-maybe": "~0.3.4"
   },
   "repository": {

--- a/bower.json
+++ b/bower.json
@@ -18,5 +18,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/paf31/purescript-webidl.git"
+  },
+  "devDependencies": {
+    "purescript-console": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "devDependencies": {
+    "webidl2": "git@github.com:darobin/webidl2.js.git#bd216bcd5596d6073"
+  },
+  "peerDependencies": {
+    "webidl2": "git@github.com:darobin/webidl2.js.git#bd216bcd5596d6073"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "scripts": {
+    "postinstall": "bower install",
+    "test": "pulp test"
+  },
   "devDependencies": {
     "webidl2": "git@github.com:darobin/webidl2.js.git#bd216bcd5596d6073"
   },

--- a/src/WebIDL.purs
+++ b/src/WebIDL.purs
@@ -8,19 +8,19 @@ module WebIDL
   , parse
   ) where
 
-import Prelude
+import Prelude (class Show, (<<<), show, (<>), ($), return, bind, (<$>))
 
-import Data.Maybe
-import Data.Either
-import Data.Generic
-import Data.Foreign
-import Data.Foreign.Class
-import Data.Foreign.NullOrUndefined
+import Data.Maybe (Maybe)
+import Data.Either (Either(Left, Right))
+import Data.Generic (class Generic, gShow)
+import Data.Foreign (ForeignError, Foreign, toForeign)
+import Data.Foreign.Class (class IsForeign, read, readProp)
+import Data.Foreign.NullOrUndefined (runNullOrUndefined)
 import Data.Traversable (traverse)
 
 import Control.Alt ((<|>))
 import Control.Bind ((>=>))
-import Control.Monad.Eff
+import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (EXCEPTION(), error, throwException)
 
 data Type

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,11 +1,10 @@
 module Test.Main where
 
-import Prelude
-import Data.Generic
-import Control.Monad.Eff
-import Control.Monad.Eff.Console (CONSOLE(), print)
-import Control.Monad.Eff.Exception (EXCEPTION())
-import WebIDL
+import Prelude (Unit, bind)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, print)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import WebIDL (parse)
 
 idl :: String
 idl = """


### PR DESCRIPTION
I've marked this as WIP since I still need to address the following error. Any tips are appreciated!

```
Error found:
in module WebIDL
at /Users/py/git/paf31/purescript-webidl/src/WebIDL.purs line 48, column 1 - line 50, column 1

  Could not match type

    String

  with type

    Array
      { sigConstructor :: String
      , sigValues :: Array (Unit -> GenericSignature)
      }


while checking that type String
  is at least as general as type Array
                                   { sigConstructor :: String
                                   , sigValues :: Array (Unit -> GenericSignature)
                                   }
while checking that expression "WebIDL.Type"
  has type Array
             { sigConstructor :: String
             , sigValues :: Array (Unit -> GenericSignature)
             }
in value declaration genericType
```
