### PR TITLE
Fix type of ConstantMember idlType field

### DIFF
--- a/src/WebIDL.purs
+++ b/src/WebIDL.purs
@@ -93,7 +93,7 @@ data Member
     }
   | ConstantMember
     { name            :: String
-    , idlType         :: String
+    , idlType         :: Type
     , nullable        :: Boolean
     }
   | FieldMember


### PR DESCRIPTION
I've yet to verify this but I imagine this change is correct.

cc @paf31 
